### PR TITLE
Fixes quality prefix application logic

### DIFF
--- a/src/shared/hooks/useCommonItemsWorker.ts
+++ b/src/shared/hooks/useCommonItemsWorker.ts
@@ -16,13 +16,13 @@ import type {
 } from "../../app/providers/SettingsContext";
 import {
   LocaleItem,
-  SUPPORTED_LOCALES,
   GAME_PATHS,
   loadSavedSettings,
   generateFinalItemName,
   generateFinalPotionName,
 } from "../utils/commonUtils";
 import { STORAGE_KEYS } from "../constants";
+type SupportedLocaleKey = Exclude<keyof LocaleItem, "id" | "Key">;
 
 type UpdateCommonItemSettingsFunction = (
   item:
@@ -335,10 +335,10 @@ export const useCommonItemsWorker = (
       const updatedModifiers = [...modifiersData];
 
       // Обновляем только выбранные локали из настроек приложения
-      const selectedLocales = (
-        JSON.parse(localStorage.getItem(STORAGE_KEYS.APP_CONFIG) || "{}")?.
-          selectedLocales
-      ) || ["enUS"];
+      const selectedLocales =
+        ((JSON.parse(localStorage.getItem(STORAGE_KEYS.APP_CONFIG) || "{}")?.
+          selectedLocales) as SupportedLocaleKey[]) ||
+        (["enUS"] as SupportedLocaleKey[]);
 
       // Обновляем простые предметы
       Object.entries(settingsKeyToCommonItemMapper).forEach(
@@ -378,7 +378,7 @@ export const useCommonItemsWorker = (
 
                 if (itemIndex !== -1) {
                   // Обновляем существующий элемент только для выбранных локалей
-                  selectedLocales.forEach((locale) => {
+                  selectedLocales.forEach((locale: SupportedLocaleKey) => {
                     if (levelSettings.enabled) {
                       const finalName = generateFinalPotionName(
                         levelSettings,
@@ -411,7 +411,7 @@ export const useCommonItemsWorker = (
                   };
 
                   // Заполняем только выбранные локали
-                  selectedLocales.forEach((locale) => {
+                  selectedLocales.forEach((locale: SupportedLocaleKey) => {
                     if (levelSettings.enabled) {
                       const finalName = generateFinalPotionName(
                         levelSettings,
@@ -449,7 +449,7 @@ export const useCommonItemsWorker = (
 
               if (itemIndex !== -1) {
                 // Обновляем существующий элемент только для выбранных локалей
-                selectedLocales.forEach((locale) => {
+                selectedLocales.forEach((locale: SupportedLocaleKey) => {
                   if (itemSettings.enabled) {
                     const finalName = generateFinalItemName(
                       itemSettings,
@@ -482,7 +482,7 @@ export const useCommonItemsWorker = (
                 };
 
                 // Заполняем только выбранные локали
-                selectedLocales.forEach((locale) => {
+                selectedLocales.forEach((locale: SupportedLocaleKey) => {
                   if (itemSettings.enabled) {
                     const finalName = generateFinalItemName(
                       itemSettings,

--- a/src/shared/hooks/useCommonItemsWorker.ts
+++ b/src/shared/hooks/useCommonItemsWorker.ts
@@ -22,6 +22,7 @@ import {
   generateFinalItemName,
   generateFinalPotionName,
 } from "../utils/commonUtils";
+import { STORAGE_KEYS } from "../constants";
 
 type UpdateCommonItemSettingsFunction = (
   item:
@@ -333,6 +334,12 @@ export const useCommonItemsWorker = (
       const updatedAffixes = [...nameAffixesData];
       const updatedModifiers = [...modifiersData];
 
+      // Обновляем только выбранные локали из настроек приложения
+      const selectedLocales = (
+        JSON.parse(localStorage.getItem(STORAGE_KEYS.APP_CONFIG) || "{}")?.
+          selectedLocales
+      ) || ["enUS"];
+
       // Обновляем простые предметы
       Object.entries(settingsKeyToCommonItemMapper).forEach(
         ([settingsKey, item]) => {
@@ -370,8 +377,8 @@ export const useCommonItemsWorker = (
                 );
 
                 if (itemIndex !== -1) {
-                  // Обновляем существующий элемент
-                  SUPPORTED_LOCALES.forEach((locale) => {
+                  // Обновляем существующий элемент только для выбранных локалей
+                  selectedLocales.forEach((locale) => {
                     if (levelSettings.enabled) {
                       const finalName = generateFinalPotionName(
                         levelSettings,
@@ -379,7 +386,7 @@ export const useCommonItemsWorker = (
                       );
                       targetArray[itemIndex][locale] = finalName;
                     } else {
-                      // Если элемент отключен, очищаем все локальные поля
+                      // Если элемент отключен, очищаем только выбранные локали
                       targetArray[itemIndex][locale] = "";
                     }
                   });
@@ -403,7 +410,8 @@ export const useCommonItemsWorker = (
                     zhCN: "",
                   };
 
-                  SUPPORTED_LOCALES.forEach((locale) => {
+                  // Заполняем только выбранные локали
+                  selectedLocales.forEach((locale) => {
                     if (levelSettings.enabled) {
                       const finalName = generateFinalPotionName(
                         levelSettings,
@@ -411,7 +419,6 @@ export const useCommonItemsWorker = (
                       );
                       newItem[locale] = finalName;
                     } else {
-                      // Если элемент отключен, устанавливаем пустую строку
                       newItem[locale] = "";
                     }
                   });
@@ -441,8 +448,8 @@ export const useCommonItemsWorker = (
               );
 
               if (itemIndex !== -1) {
-                // Обновляем существующий элемент
-                SUPPORTED_LOCALES.forEach((locale) => {
+                // Обновляем существующий элемент только для выбранных локалей
+                selectedLocales.forEach((locale) => {
                   if (itemSettings.enabled) {
                     const finalName = generateFinalItemName(
                       itemSettings,
@@ -450,7 +457,7 @@ export const useCommonItemsWorker = (
                     );
                     targetArray[itemIndex][locale] = finalName;
                   } else {
-                    // Если элемент отключен, очищаем все локальные поля
+                    // Если элемент отключен, очищаем только выбранные локали
                     targetArray[itemIndex][locale] = "";
                   }
                 });
@@ -474,7 +481,8 @@ export const useCommonItemsWorker = (
                   zhCN: "",
                 };
 
-                SUPPORTED_LOCALES.forEach((locale) => {
+                // Заполняем только выбранные локали
+                selectedLocales.forEach((locale) => {
                   if (itemSettings.enabled) {
                     const finalName = generateFinalItemName(
                       itemSettings,
@@ -482,7 +490,6 @@ export const useCommonItemsWorker = (
                     );
                     newItem[locale] = finalName;
                   } else {
-                    // Если элемент отключен, устанавливаем пустую строку
                     newItem[locale] = "";
                   }
                 });

--- a/src/shared/hooks/useGemsWorker.ts
+++ b/src/shared/hooks/useGemsWorker.ts
@@ -18,6 +18,8 @@ import {
   generateFinalGemName,
 } from "../utils/commonUtils";
 import { STORAGE_KEYS } from "../constants";
+import type { LocaleItem as ItemLocaleItem } from "../utils/commonUtils";
+type SupportedLocaleKey = Exclude<keyof ItemLocaleItem, "id" | "Key">;
 
 type UpdateGemGroupSettingsFunction = (
   gem:
@@ -221,10 +223,10 @@ export const useGemsWorker = (
       const updatedNameAffixesData = [...nameAffixesData];
 
       // Обновляем только выбранные локали из настроек приложения
-      const selectedLocales = (
-        JSON.parse(localStorage.getItem(STORAGE_KEYS.APP_CONFIG) || "{}")?.
-          selectedLocales
-      ) || ["enUS"];
+      const selectedLocales =
+        ((JSON.parse(localStorage.getItem(STORAGE_KEYS.APP_CONFIG) || "{}")?.
+          selectedLocales) as SupportedLocaleKey[]) ||
+        (["enUS"] as SupportedLocaleKey[]);
 
       // Обрабатываем каждую группу драгоценных камней
       Object.entries(settingsKeyToGemMapper).forEach(([settingsKey, gems]) => {
@@ -250,7 +252,7 @@ export const useGemsWorker = (
 
               if (itemIndex !== -1) {
                 // Обновляем существующий элемент только для выбранных локалей
-                selectedLocales.forEach((locale) => {
+                selectedLocales.forEach((locale: SupportedLocaleKey) => {
                   if (levelSettings.enabled) {
                     const finalName = generateFinalGemName(
                       levelSettings,
@@ -283,7 +285,7 @@ export const useGemsWorker = (
                 };
 
                 // Заполняем только выбранные локали
-                selectedLocales.forEach((locale) => {
+                selectedLocales.forEach((locale: SupportedLocaleKey) => {
                   if (levelSettings.enabled) {
                     const finalName = generateFinalGemName(
                       levelSettings,

--- a/src/shared/hooks/useGemsWorker.ts
+++ b/src/shared/hooks/useGemsWorker.ts
@@ -17,6 +17,7 @@ import {
   loadSavedSettings,
   generateFinalGemName,
 } from "../utils/commonUtils";
+import { STORAGE_KEYS } from "../constants";
 
 type UpdateGemGroupSettingsFunction = (
   gem:
@@ -219,6 +220,12 @@ export const useGemsWorker = (
       const updatedItemNamesData = [...itemNamesData];
       const updatedNameAffixesData = [...nameAffixesData];
 
+      // Обновляем только выбранные локали из настроек приложения
+      const selectedLocales = (
+        JSON.parse(localStorage.getItem(STORAGE_KEYS.APP_CONFIG) || "{}")?.
+          selectedLocales
+      ) || ["enUS"];
+
       // Обрабатываем каждую группу драгоценных камней
       Object.entries(settingsKeyToGemMapper).forEach(([settingsKey, gems]) => {
         const gemGroupSettings = gemSettings[settingsKey as keyof GemSettings];
@@ -242,8 +249,8 @@ export const useGemsWorker = (
               );
 
               if (itemIndex !== -1) {
-                // Обновляем существующий элемент
-                SUPPORTED_LOCALES.forEach((locale) => {
+                // Обновляем существующий элемент только для выбранных локалей
+                selectedLocales.forEach((locale) => {
                   if (levelSettings.enabled) {
                     const finalName = generateFinalGemName(
                       levelSettings,
@@ -251,7 +258,7 @@ export const useGemsWorker = (
                     );
                     targetData[itemIndex][locale] = finalName;
                   } else {
-                    // Если элемент отключен, очищаем все локальные поля
+                    // Если элемент отключен, очищаем только выбранные локали
                     targetData[itemIndex][locale] = "";
                   }
                 });
@@ -275,7 +282,8 @@ export const useGemsWorker = (
                   zhCN: "",
                 };
 
-                SUPPORTED_LOCALES.forEach((locale) => {
+                // Заполняем только выбранные локали
+                selectedLocales.forEach((locale) => {
                   if (levelSettings.enabled) {
                     const finalName = generateFinalGemName(
                       levelSettings,
@@ -283,7 +291,6 @@ export const useGemsWorker = (
                     );
                     newItem[locale] = finalName;
                   } else {
-                    // Если элемент отключен, устанавливаем пустую строку
                     newItem[locale] = "";
                   }
                 });

--- a/src/shared/hooks/useItemsWorker.ts
+++ b/src/shared/hooks/useItemsWorker.ts
@@ -418,62 +418,61 @@ export const useItemsWorker = (
         }
       }
 
-      // Обрабатываем Quality Prefixes
+      // Обрабатываем Quality Prefixes (по уровням)
       const qualityPrefixes = itemsSettings.qualityPrefixes;
-      if (qualityPrefixes.enabled) {
-        // Superior level (1) - записываем только в ID 1727
-        const superiorLevel = qualityPrefixes.levels[1];
-        if (superiorLevel) {
-          const superiorLocale = updatedNameAffixesData.find(
-            (locale) => locale.id === 1727
-          );
-          if (superiorLocale) {
-            for (const locale of selectedLocales) {
-              const localeKey = locale as keyof LocaleItem;
-              const settingsLocaleKey =
-                locale as keyof typeof superiorLevel.locales;
-              const prefixName = superiorLevel.locales[settingsLocaleKey];
 
-              if (prefixName && prefixName.trim()) {
-                (superiorLocale as any)[localeKey] = prefixName;
-              }
+      // Superior level (1) - записываем только в ID 1727, если уровень включен
+      const superiorLevel = qualityPrefixes.levels[1];
+      if (superiorLevel?.enabled) {
+        const superiorLocale = updatedNameAffixesData.find(
+          (locale) => locale.id === 1727
+        );
+        if (superiorLocale) {
+          for (const locale of selectedLocales) {
+            const localeKey = locale as keyof LocaleItem;
+            const settingsLocaleKey =
+              locale as keyof typeof superiorLevel.locales;
+            const prefixName = superiorLevel.locales[settingsLocaleKey];
+
+            if (prefixName && prefixName.trim()) {
+              (superiorLocale as any)[localeKey] = prefixName;
             }
           }
         }
+      }
 
-        // Low Quality level (0) - записываем в ID 1723, 1724, 1725, 20910
-        const lowQualityLevel = qualityPrefixes.levels[0];
-        if (lowQualityLevel) {
-          const lowQualityIds = [1723, 1724, 1725, 20910];
+      // Low Quality level (0) - записываем в ID 1723, 1724, 1725, 20910, если уровень включен
+      const lowQualityLevel = qualityPrefixes.levels[0];
+      if (lowQualityLevel?.enabled) {
+        const lowQualityIds = [1723, 1724, 1725, 20910];
 
-          // Проверяем, есть ли хотя бы одно непустое значение
-          const hasNonEmptyValues = selectedLocales.some((locale) => {
-            const settingsLocaleKey =
-              locale as keyof typeof lowQualityLevel.locales;
-            const prefixName = lowQualityLevel.locales[settingsLocaleKey];
-            return prefixName && prefixName.trim();
-          });
+        // Проверяем, есть ли хотя бы одно непустое значение среди выбранных локалей
+        const hasNonEmptyValues = selectedLocales.some((locale) => {
+          const settingsLocaleKey =
+            locale as keyof typeof lowQualityLevel.locales;
+          const prefixName = lowQualityLevel.locales[settingsLocaleKey];
+          return prefixName && prefixName.trim();
+        });
 
-          // Записываем только если есть непустые значения
-          if (hasNonEmptyValues) {
-            lowQualityIds.forEach((id) => {
-              const prefixLocale = updatedNameAffixesData.find(
-                (locale) => locale.id === id
-              );
-              if (prefixLocale) {
-                for (const locale of selectedLocales) {
-                  const localeKey = locale as keyof LocaleItem;
-                  const settingsLocaleKey =
-                    locale as keyof typeof lowQualityLevel.locales;
-                  const prefixName = lowQualityLevel.locales[settingsLocaleKey];
+        // Записываем только если есть непустые значения
+        if (hasNonEmptyValues) {
+          lowQualityIds.forEach((id) => {
+            const prefixLocale = updatedNameAffixesData.find(
+              (locale) => locale.id === id
+            );
+            if (prefixLocale) {
+              for (const locale of selectedLocales) {
+                const localeKey = locale as keyof LocaleItem;
+                const settingsLocaleKey =
+                  locale as keyof typeof lowQualityLevel.locales;
+                const prefixName = lowQualityLevel.locales[settingsLocaleKey];
 
-                  if (prefixName && prefixName.trim()) {
-                    (prefixLocale as any)[localeKey] = prefixName;
-                  }
+                if (prefixName && prefixName.trim()) {
+                  (prefixLocale as any)[localeKey] = prefixName;
                 }
               }
-            });
-          }
+            }
+          });
         }
       }
 

--- a/src/shared/hooks/useItemsWorker.ts
+++ b/src/shared/hooks/useItemsWorker.ts
@@ -376,9 +376,9 @@ export const useItemsWorker = (
         );
         if (!itemLocale) continue;
 
-        // Если предмет выключен — очищаем ВСЕ поддерживаемые локали в файле и идем дальше
+        // Если предмет выключен — очищаем только выбранные локали и идем дальше
         if (!itemSettings?.enabled) {
-          for (const locale of SUPPORTED_LOCALES) {
+          for (const locale of selectedLocales) {
             const localeKey = locale as keyof LocaleItem;
             (itemLocale as any)[localeKey] = "";
           }


### PR DESCRIPTION
Updates the quality prefix application to correctly apply prefixes based on level enablement.

- Ensures prefixes for 'Superior' and 'Low Quality' levels are only applied when the level is enabled in the settings.
- Adds a check to ensure at least one non-empty value exists for Low Quality prefixes before applying them to avoid unnecessary updates.