### PR TITLE
Root error boundary + startup storage hardening (no more unrecoverable white screen)

### DIFF
--- a/src/app/entrypoint-components/App.tsx
+++ b/src/app/entrypoint-components/App.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useLogger } from "../../shared/utils/logger";
+import { safeGetItem } from "../../shared/utils/safeStorage";
 import ProgressBar from "../../shared/components/ProgressBar.tsx";
 import CustomTitleBar from "../../widgets/CustomTitleBar.tsx";
 import StartupLanguageSwitch from "../../widgets/Toolbar/StartupLanguageSwitch.tsx";
@@ -82,9 +83,10 @@ type AppState =
 function App() {
   const logger = useLogger("App");
   const [appState, setAppState] = useState<AppState>("loading");
-  const isDebugMode = Number(
-    localStorage.getItem(STORAGE_KEYS.DEBUG_MODE) || 0
-  );
+  // safeGetItem: storage access can throw (blocked/disabled WebView2 storage); this read
+  // runs in the component body during the very first render, where an uncaught throw would
+  // blank the whole window.
+  const isDebugMode = Number(safeGetItem(STORAGE_KEYS.DEBUG_MODE) || 0);
   const { t } = useTranslation();
 
   // Тестовое логирование при инициализации

--- a/src/app/providers/SettingsContext.tsx
+++ b/src/app/providers/SettingsContext.tsx
@@ -13,6 +13,7 @@ import i18n from "../../shared/i18n";
 import { STORAGE_KEYS } from "../../shared/constants";
 import { logger } from "../../shared/utils/logger";
 import { saveTextViaDialog } from "../../shared/utils/saveFile";
+import { safeParse } from "../../shared/utils/safeStorage";
 // Загружаем профили из ассетов (eager, чтобы были доступны синхронно)
 // Новый формат: recommendedProfiles + корневой d2r-profile-Default.json
 // Для обратной совместимости поддерживаем старые пути (baseProfiles)
@@ -1414,11 +1415,17 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({
     if (savedSettings) {
       try {
         const parsedSettings = JSON.parse(savedSettings);
+        // runes может отсутствовать в старом/частичном/импортированном сохранении —
+        // берём дефолт, иначе Object.entries(undefined) бросит и потеряет ВСЕ настройки.
+        const runesSource =
+          parsedSettings?.runes && typeof parsedSettings.runes === "object"
+            ? parsedSettings.runes
+            : createDefaultSettings().runes;
         // Мигрируем настройки рун и добавляем common и gems если их нет
         const migratedSettings = {
           ...parsedSettings,
           runes: Object.fromEntries(
-            Object.entries(parsedSettings.runes).map(([key, value]) => [
+            Object.entries(runesSource).map(([key, value]) => [
               key,
               migrateRuneSettings(value),
             ])
@@ -1445,31 +1452,36 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({
     let hadProfiles = false;
     if (savedProfiles) {
       try {
-        const parsedProfiles = JSON.parse(savedProfiles);
-        // Мигрируем настройки рун в загруженных профилях и добавляем common и gems если их нет
-        const migratedProfiles = parsedProfiles.map((profile: Profile) => ({
+        // safeParse + Array-guard: битый/несовместимый JSON не должен ронять загрузку.
+        const parsedProfiles = safeParse<Profile[]>(savedProfiles, []);
+        const profilesList = Array.isArray(parsedProfiles) ? parsedProfiles : [];
+        // Мигрируем настройки рун в загруженных профилях и добавляем common и gems если их нет.
+        // profile.settings(.runes) может отсутствовать в старом/импортированном профиле.
+        const migratedProfiles = profilesList.map((profile: Profile) => ({
           ...profile,
             settings: {
             ...profile.settings,
             runes: Object.fromEntries(
-              Object.entries(profile.settings.runes).map(([key, value]) => [
-                key,
-                migrateRuneSettings(value),
-              ])
-            ),
-            common: profile.settings.common
+              Object.entries(
+                profile.settings?.runes &&
+                  typeof profile.settings.runes === "object"
+                  ? profile.settings.runes
+                  : createDefaultSettings().runes
+              ).map(([key, value]) => [key, migrateRuneSettings(value)])
+            ) as Record<ERune, RuneSettings>,
+            common: profile.settings?.common
               ? cleanSettings(profile.settings.common)
               : getDefaultCommonSettings(),
-            gems: profile.settings.gems
+            gems: profile.settings?.gems
               ? profile.settings.gems
               : getDefaultGemSettings(),
-            items: profile.settings.items
+            items: profile.settings?.items
               ? migrateItemsSettings(profile.settings.items)
               : getDefaultItemsSettings(),
               // Tweaks не храним в профилях вообще
               tweaks: getDefaultTweaksSettings(),
             modifiers: migrateModifiersSettings(
-              (profile.settings as any).modifiers
+              (profile.settings as any)?.modifiers
             ),
           },
         }));

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import App from "./app/entrypoint-components/App.tsx";
 import RunCounterOverlay from "./app/entrypoint-components/RunCounterOverlay.tsx";
 import RunCounterDisplay from "./app/entrypoint-components/RunCounterDisplay.tsx";
 import RunCounterSessionOverlay from "./app/entrypoint-components/RunCounterSessionOverlay.tsx";
+import RootErrorBoundary from "./shared/components/RootErrorBoundary.tsx";
 import {
   OVERLAY_WINDOW_LABEL,
   DISPLAY_WINDOW_LABEL,
@@ -12,6 +13,8 @@ import {
 } from "./shared/runcounter/constants.ts";
 import "./app/entrypoint-components/App.css";
 import "./shared/assets/fonts.css";
+// NOTE: import-time code (this i18n init, and anything it triggers) runs BEFORE createRoot,
+// so RootErrorBoundary below cannot catch throws from here — keep module-eval code throw-safe.
 import "./shared/i18n";
 
 // Both windows load this same bundle; the window label decides which UI to render.
@@ -43,5 +46,7 @@ const rootUI = isOverlay ? (
 );
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>{rootUI}</React.StrictMode>
+  <React.StrictMode>
+    <RootErrorBoundary>{rootUI}</RootErrorBoundary>
+  </React.StrictMode>
 );

--- a/src/shared/components/RootErrorBoundary.tsx
+++ b/src/shared/components/RootErrorBoundary.tsx
@@ -1,0 +1,184 @@
+import React from "react";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/**
+ * Last-resort error boundary mounted above every window root in main.tsx.
+ *
+ * Without it, any uncaught throw during render unmounts the whole tree and leaves a
+ * permanent blank white window (no Vite overlay in production) — and the in-app updater
+ * never mounts, so the app can't even auto-fix itself. This converts that into a readable
+ * recovery screen with a one-click "Reset & restart" that wipes the app's persisted state.
+ *
+ * It must keep working even when antd / i18n / the settings context are exactly what
+ * crashed, so it depends only on React + inline styles + hardcoded bilingual (EN/RU) copy.
+ */
+class RootErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    // Surface to any attached console / DevTools for diagnosis.
+    console.error("RootErrorBoundary caught:", error, info?.componentStack);
+  }
+
+  private handleRestart = (): void => {
+    window.location.reload();
+  };
+
+  private handleReset = (): void => {
+    // Blanket clear so recovery is exhaustive — every app key (incl. ad-hoc ones not in
+    // STORAGE_KEYS) is wiped, and localStorage is per-origin so nothing else is affected.
+    try {
+      localStorage.clear();
+      sessionStorage.clear();
+    } catch {
+      /* storage unavailable — nothing we can do */
+    }
+    window.location.reload();
+  };
+
+  render(): React.ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    const details = `${error.message || String(error)}\n\n${error.stack || ""}`.trim();
+
+    return (
+      <div style={styles.overlay}>
+        <div style={styles.card}>
+          <div style={styles.title}>Something went wrong · Что-то пошло не так</div>
+
+          <p style={styles.text}>
+            The app failed to start. Try restarting first; if it keeps happening, reset its
+            saved data. Resetting clears your loot-filter settings and profiles — export a
+            profile first if you can.
+          </p>
+          <p style={styles.textMuted}>
+            Не удалось запустить приложение. Сначала попробуйте перезапустить; если не
+            помогает — сбросьте сохранённые данные. Сброс очистит настройки фильтра и
+            профили — если можете, сначала экспортируйте профиль.
+          </p>
+
+          <div style={styles.buttons}>
+            <button style={styles.secondaryBtn} onClick={this.handleRestart} type="button">
+              Restart · Перезапустить
+            </button>
+            <button style={styles.primaryBtn} onClick={this.handleReset} type="button">
+              Reset &amp; restart · Сбросить и перезапустить
+            </button>
+          </div>
+
+          <details style={styles.details}>
+            <summary style={styles.summary}>Error details · Детали ошибки</summary>
+            <pre style={styles.pre}>{details}</pre>
+          </details>
+        </div>
+      </div>
+    );
+  }
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  overlay: {
+    position: "fixed",
+    inset: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+    background: "#111827",
+    color: "#e5e7eb",
+    fontFamily:
+      "'Segoe UI', system-ui, -apple-system, Roboto, Helvetica, Arial, sans-serif",
+    overflow: "auto",
+    zIndex: 2147483647,
+  },
+  card: {
+    width: "100%",
+    maxWidth: 520,
+    background: "#1f2937",
+    border: "1px solid #374151",
+    borderRadius: 12,
+    padding: 24,
+    boxSizing: "border-box",
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 700,
+    color: "#fbbf24",
+    marginBottom: 12,
+  },
+  text: {
+    fontSize: 14,
+    lineHeight: 1.5,
+    margin: "0 0 8px",
+  },
+  textMuted: {
+    fontSize: 13,
+    lineHeight: 1.5,
+    color: "#9ca3af",
+    margin: "0 0 20px",
+  },
+  buttons: {
+    display: "flex",
+    gap: 10,
+    flexWrap: "wrap",
+  },
+  secondaryBtn: {
+    flex: 1,
+    minWidth: 160,
+    padding: "10px 14px",
+    borderRadius: 8,
+    border: "1px solid #4b5563",
+    background: "#374151",
+    color: "#e5e7eb",
+    fontSize: 14,
+    cursor: "pointer",
+  },
+  primaryBtn: {
+    flex: 1,
+    minWidth: 160,
+    padding: "10px 14px",
+    borderRadius: 8,
+    border: "1px solid #f59e0b",
+    background: "#f59e0b",
+    color: "#111827",
+    fontSize: 14,
+    fontWeight: 600,
+    cursor: "pointer",
+  },
+  details: {
+    marginTop: 18,
+  },
+  summary: {
+    fontSize: 12,
+    color: "#9ca3af",
+    cursor: "pointer",
+  },
+  pre: {
+    marginTop: 8,
+    maxHeight: 180,
+    overflow: "auto",
+    background: "#0b1220",
+    border: "1px solid #374151",
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 11,
+    lineHeight: 1.4,
+    color: "#cbd5e1",
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+  },
+};
+
+export default RootErrorBoundary;

--- a/src/shared/utils/safeStorage.ts
+++ b/src/shared/utils/safeStorage.ts
@@ -1,0 +1,27 @@
+// Defensive localStorage helpers. WebView2 storage can be blocked/disabled (privacy
+// policy, group policy, a corrupted store), and persisted JSON can be partial/old —
+// either of which throws. These keep startup reads from ever crashing the first render.
+
+/** localStorage.getItem that returns null instead of throwing when storage is unavailable. */
+export const safeGetItem = (key: string): string | null => {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * JSON.parse a (possibly null) raw string, returning `fallback` on any failure:
+ * null/missing input, malformed JSON, or a null result. Non-null scalars and objects
+ * pass through, so callers that need an object/array must still validate the shape.
+ */
+export const safeParse = <T>(raw: string | null, fallback: T): T => {
+  if (raw == null) return fallback;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed == null ? fallback : (parsed as T);
+  } catch {
+    return fallback;
+  }
+};


### PR DESCRIPTION
@
## Проблема

В приложении не было ни одного React error boundary. Любое необработанное исключение при рендере обрушивало всё дерево в **пустое белое окно** (в проде нет оверлея ошибок), и внутриигровой апдейтер не успевал примонтироваться — то есть приложение не могло даже само себя починить автообновлением.

## Что сделано

- **`RootErrorBoundary`** — верхнеуровневый boundary без внешних зависимостей, смонтирован над корнем **всех 4 окон** в `main.tsx`. Вместо белого экрана показывает читаемый двуязычный (рус/англ) экран восстановления с кнопками **«Перезапустить»** и **«Сбросить и перезапустить»** (вторая чистит localStorage/sessionStorage и перезагружает). Это и есть реальное лекарство от белого экрана.
- **`safeStorage`** — `safeGetItem` (доступ к storage может бросить, если он заблокирован/выключен) + `safeParse`. `App.tsx` читает `DEBUG_MODE` через `safeGetItem` — это было единственное незащищённое чтение localStorage на пути первого рендера.
- **`SettingsContext`** — защита `settings.runes` / `profile.settings.runes` перед `Object.entries` и Array-guard при парсинге профилей. Эти места уже были в try/catch (белый экран не давали), но при частичном сохранении молча сбрасывали ВСЕ настройки/профили — теперь частичное сохранение мигрирует, а не теряется.

## Проверки
`npm run tcheck` ✅ · прод-сборка ✅ · состязательное ревью (подтвердило, что boundary над каждым `SettingsProvider`; по его findings включён полный `clear()` в Reset и исключён посторонний даунгрейд `Cargo.lock`).

Бэкграунд: см. диагностику белого экрана — корень оказался плавающим/средовым (не от данных), но отсутствие boundary делало любой такой сбой неустранимым.
@