### PR TITLE
Run Counter: display toggle beside the title

### DIFF
--- a/src/widgets/Toolbar/MainSpaceToolbar.tsx
+++ b/src/widgets/Toolbar/MainSpaceToolbar.tsx
@@ -36,13 +36,17 @@ const MainSpaceToolbar: React.FC<ToolbarProps> = ({
       }`}
     >
       {title && (
-        <span
-          className={`absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 diablo-font text-lg font-bold whitespace-nowrap pointer-events-none ${
-            isDarkTheme ? "text-white" : "text-gray-900"
-          }`}
-        >
-          {title}
-        </span>
+        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center gap-2 pointer-events-none">
+          <span
+            className={`diablo-font text-lg font-bold whitespace-nowrap ${
+              isDarkTheme ? "text-white" : "text-gray-900"
+            }`}
+          >
+            {title}
+          </span>
+          {/* Display toggle sits right next to the title (re-enable clicks). */}
+          {rightExtra && <span className="pointer-events-auto">{rightExtra}</span>}
+        </div>
       )}
       <div className="flex justify-between items-center h-full">
         <div className="flex items-center space-x-4">
@@ -80,7 +84,8 @@ const MainSpaceToolbar: React.FC<ToolbarProps> = ({
         </div>
 
         <div className="flex items-center space-x-4">
-          {rightExtra}
+          {/* rightExtra normally sits beside the centered title; fall back here if no title. */}
+          {!title && rightExtra}
           {/* Theme Toggle */}
           <Tooltip
             title={isDarkTheme ? t("common.lightTheme") : t("common.darkTheme")}


### PR DESCRIPTION
Moves the Run Counter display toggle from the far-right toolbar group to right beside the centered section title (its natural place). When a title is present the button renders next to it (clicks re-enabled via pointer-events); otherwise it falls back to the right group. tcheck + check-i18n green.