### PR TITLE
Runes: fix list overflow so last runes (Cham, Zod) aren't clipped

### DIFF
--- a/src/pages/runes/RunesSpecific.tsx
+++ b/src/pages/runes/RunesSpecific.tsx
@@ -280,13 +280,13 @@ const RunesSpecific: React.FC<RunesSpecificProps> = ({
     <div className="flex h-full">
       {/* Левая панель - список рун */}
       <div
-        className={`w-96 flex-shrink-0 border-r ${
+        className={`w-96 flex-shrink-0 border-r flex flex-col min-h-0 ${
           isDarkTheme ? "border-gray-700" : "border-gray-200"
         }`}
       >
         {/* Навигационный блок */}
         <div
-          className={`py-4 px-2 border-b ${
+          className={`py-4 px-2 border-b flex-shrink-0 ${
             isDarkTheme ? "border-gray-700" : "border-gray-200"
           }`}
         >
@@ -423,7 +423,7 @@ const RunesSpecific: React.FC<RunesSpecificProps> = ({
         </div>
 
         {/* Список рун */}
-        <div className="overflow-y-auto max-h-[calc(100vh-280px)]">
+        <div className="flex-1 min-h-0 overflow-y-auto">
           {filteredAndSortedRunes.length === 0 ? (
             <div className="text-center py-12">
               <p


### PR DESCRIPTION
## Summary
The rune list on the Runes tab used a hardcoded `max-h-[calc(100vh-280px)]`, which didn't account for the actual toolbar/header height. As a result, the bottom of the list was cut off and the last runes (Cham, Zod) were hidden below the scroll area.

## Fix
- Make the left panel a proper flex column (`flex flex-col min-h-0`) with the toolbar block as `flex-shrink-0`.
- Replace the hardcoded `max-h-[calc(100vh-280px)]` on the scroll container with `flex-1 min-h-0 overflow-y-auto`, so it fills whatever vertical space is available.

## Test plan
- [x] `npm run tcheck` passes
- [ ] Open the Runes tab in the running app — verify Cham and Zod are visible at the bottom of the list and the scroll behaves correctly in both basic and advanced window sizes.